### PR TITLE
Add custom redraw method for TileLayer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "dash-leaflet",
-      "version": "1.0.13",
+      "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",

--- a/src/ts/components/TileLayer.tsx
+++ b/src/ts/components/TileLayer.tsx
@@ -1,25 +1,85 @@
-import React from 'react';
-import { TileLayer as ReactLeafletTileLayer } from 'react-leaflet';
-import {TileLayerProps, assignLoadEventHandlers, LoadComponent, Modify} from "../props";
+import React, { useEffect, useRef, useState } from 'react';
+import { TileLayer as ReactLeafletTileLayer, useMap } from 'react-leaflet';
+import { TileLayerProps, assignLoadEventHandlers, LoadComponent, Modify } from "../props";
+import L from 'leaflet';
+
+// Override redraw method in L.GridLayer to round Zoom levels
+L.GridLayer.include({
+	redraw() {
+		if (this._map) {
+			this._removeAllTiles();
+			const tileZoom = Math.round(this._clampZoom(this._map.getZoom()));
+			if (tileZoom !== this._tileZoom) {
+				this._tileZoom = tileZoom;
+				this._updateLevels();
+			}
+			this._update();
+		}
+		return this;
+	},
+});
+
+// Use the extended L.GridLayer
+class CustomTileLayer extends L.TileLayer {
+	redraw(): this {
+		(L.GridLayer.prototype as any).redraw.call(this);
+		return this;
+	}
+}
+
+const createCustomTileLayer = (url: string, props: L.TileLayerOptions) => {
+	return new CustomTileLayer(url, props);
+}
 
 type Props = Modify<TileLayerProps, {
-    /**
-     * The URL template in the form 'https://{s}.somedomain.com/blabla/{z}/{x}/{y}{r}.png'. [MUTABLE, DL]
-     */
-    url?: string;
+	/**
+	 * The URL template in the form 'https://{s}.somedomain.com/blabla/{z}/{x}/{y}{r}.png'. [MUTABLE, DL]
+	 */
+	url?: string;
 } & LoadComponent>;
 
 /**
  * Used to load and display tile layers on the map. Note that most tile servers require attribution.
  */
-const TileLayer = ({ 
-    // Set default to OSM
-    url = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-    ...props
+const TileLayer = ({
+	// Set default to OSM
+	url = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+	...props
 }: Props) => {
-    return (
-        <ReactLeafletTileLayer url={url} {...assignLoadEventHandlers(props)}></ReactLeafletTileLayer>
-    )
-}
+	const tileLayerRef = useRef<CustomTileLayer | null>(null);
+	const map = useMap();
+
+	// Use state to track when redraw is necessary
+	const [redrawNeeded, setRedrawNeeded] = useState(false);
+
+	useEffect(() => {
+		if (redrawNeeded && tileLayerRef.current) {
+			tileLayerRef.current.redraw();
+			setRedrawNeeded(false); // Reset the redraw flag
+		}
+	}, [redrawNeeded]);
+
+	useEffect(() => {
+		setRedrawNeeded(true);
+	}, [url, props.attribution]);
+
+	return (
+		<ReactLeafletTileLayer
+			url={url}
+			{...assignLoadEventHandlers(props)}
+			ref={(instance) => {
+				if (instance) {
+					tileLayerRef.current = createCustomTileLayer(url, props);
+					map.addLayer(tileLayerRef.current);
+				} else {
+					if (tileLayerRef.current) {
+						map.removeLayer(tileLayerRef.current);
+					}
+					tileLayerRef.current = null;
+				}
+			}}
+		/>
+	);
+};
 
 export default TileLayer;


### PR DESCRIPTION
### Description

Adds custom `redraw` method to `TileLayer` to round Zoom levels and fix the issue #236 

This fix is a workaround suggested in [this comment](https://github.com/Leaflet/Leaflet/pull/9376#issuecomment-2179303581) by Leaflet.js maintainers.

### Test fix:
- Use sample code in #236 

