### PR TITLE
add mouse position support to dash leaflet

### DIFF
--- a/dash_leaflet/_imports_.py
+++ b/dash_leaflet/_imports_.py
@@ -17,6 +17,7 @@ from .LocateControl import LocateControl
 from .MapContainer import MapContainer
 from .Marker import Marker
 from .MeasureControl import MeasureControl
+from .MousePosition import MousePosition
 from .Overlay import Overlay
 from .Pane import Pane
 from .Polygon import Polygon
@@ -52,6 +53,7 @@ __all__ = [
     "MapContainer",
     "Marker",
     "MeasureControl",
+    "MousePosition",
     "Overlay",
     "Pane",
     "Polygon",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
+        "@types/leaflet-mouse-position": "^1.2.4",
         "base64-js": "^1.5.1",
         "chroma-js": "^2.4.2",
         "flatgeobuf": "^3.26.2",
@@ -18,6 +19,7 @@
         "leaflet-easybutton": "^2.4.0",
         "leaflet-gesture-handling": "^1.2.2",
         "leaflet-measure": "^3.1.0",
+        "leaflet-mouse-position": "^1.2.0",
         "leaflet-polylinedecorator": "^1.6.0",
         "leaflet.fullscreen": "^2.4.0",
         "leaflet.locatecontrol": "^0.79.0",
@@ -611,8 +613,7 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.10",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
-      "dev": true
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -640,7 +641,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.3.tgz",
       "integrity": "sha512-Caa1lYOgKVqDkDZVWkto2Z5JtVo09spEaUt2S69LiugbBpoqQu92HYFMGUbYezZbnBkyOxMNPXHSgRrRY5UyIA==",
-      "dev": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -650,6 +650,14 @@
       "resolved": "https://registry.npmjs.org/@types/leaflet-draw/-/leaflet-draw-1.0.7.tgz",
       "integrity": "sha512-Tje5jjUC9aPmy9NSYx8HbPIVpX2VT3JyBk6wZ46PqneJzgev+UyBuK72Emvu8xaSmAEBkhlsImR7SACsdItXSw==",
       "dev": true,
+      "dependencies": {
+        "@types/leaflet": "*"
+      }
+    },
+    "node_modules/@types/leaflet-mouse-position": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-mouse-position/-/leaflet-mouse-position-1.2.4.tgz",
+      "integrity": "sha512-4lH4EOltJ1L6dPspOT3whTmsmhmlmvdYt66L3XH2YJ2n+CARw5lK+qCtgJibIlUCL2VxQzynI352WkIjTuLVgw==",
       "dependencies": {
         "@types/leaflet": "*"
       }
@@ -2611,6 +2619,11 @@
       "peerDependencies": {
         "leaflet": "^1.0.0"
       }
+    },
+    "node_modules/leaflet-mouse-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-mouse-position/-/leaflet-mouse-position-1.2.0.tgz",
+      "integrity": "sha512-iKS25GZDRdoKZn0O5sjTyNcBYrq/wenLiOidj4jJ5iD4SfhyqVj+bJHgBwuMxOlf8Vc/9B1ZPlqYV4QA97nyFg=="
     },
     "node_modules/leaflet-polylinedecorator": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "author": "Emil Haldrup Eriksen <emil.h.eriksen@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@types/leaflet-mouse-position": "^1.2.4",
     "base64-js": "^1.5.1",
     "chroma-js": "^2.4.2",
     "flatgeobuf": "^3.26.2",
@@ -58,6 +59,7 @@
     "leaflet-easybutton": "^2.4.0",
     "leaflet-gesture-handling": "^1.2.2",
     "leaflet-measure": "^3.1.0",
+    "leaflet-mouse-position": "^1.2.0",
     "leaflet-polylinedecorator": "^1.6.0",
     "leaflet.fullscreen": "^2.4.0",
     "leaflet.locatecontrol": "^0.79.0",

--- a/src/ts/components/MousePosition.tsx
+++ b/src/ts/components/MousePosition.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {MousePosition as ReactLeafletMousePosition, MousePositionProps} from '../react-leaflet/MousePosition';
+import { DashComponent, Modify} from "../props";
+
+type Props = Modify<MousePositionProps, DashComponent>;
+
+/**
+ *  A simple mouse position control that you can drop into your leaflet map. It displays geographic coordinates of the mouse pointer, as it is moved about the map.
+ */
+const MousePosition = (props: Props) => {
+    return (
+        <ReactLeafletMousePosition {...props}></ReactLeafletMousePosition>
+    )
+}
+
+export default MousePosition;

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -31,6 +31,7 @@ import Colorbar from './components/Colorbar';
 import MeasureControl from './components/MeasureControl';
 import EditControl from './components/EditControl';
 import GeoJSON from './components/GeoJSON';
+import MousePosition from "./components/MousePosition";
 
 export {
     MapContainer,
@@ -65,5 +66,6 @@ export {
     Colorbar,
     MeasureControl,
     EditControl,
-    GeoJSON
+    GeoJSON,
+    MousePosition
 }

--- a/src/ts/react-leaflet/MousePosition.ts
+++ b/src/ts/react-leaflet/MousePosition.ts
@@ -1,0 +1,45 @@
+import {createControlComponent} from '@react-leaflet/core'
+import "leaflet-mouse-position"
+import * as L from "leaflet";
+import {ControlProps} from "../leaflet-props";
+
+require('leaflet-mouse-position/src/L.Control.MousePosition.css');
+
+export type MousePositionProps = {
+    /**
+     * To separate longitude\latitude values. Defaults to '' : '.
+     */
+    separator?: string;
+
+    /**
+     * Initial text to display. Defaults to 'Unavailable'.
+     */
+    emptystring?: string;
+
+    /**
+     * Weather to put the longitude first or not. Defaults to false.
+     */
+    lngFirst?: boolean;
+
+    /**
+     * Number of digits. Defaults to 5.
+     */
+    numDigits?: number;
+
+    /**
+     * A string to be prepended to the coordinates. Defaults to the empty string ‘’.
+     */
+    prefix?: string;
+
+    /**
+     * Controls if longitude values will be wrapped. Defaults to true.
+     */
+    wrapLng?: boolean;
+} & ControlProps;
+
+export const MousePosition = createControlComponent<L.Control.Fullscreen, MousePositionProps>(
+
+    function createLeafletElement(props) {
+        return L.control.mousePosition(props);
+    }
+);


### PR DESCRIPTION
add `MousePosition` control (https://github.com/danwild/Leaflet.MousePosition).

![image](https://github.com/user-attachments/assets/2291ba2d-b117-4d31-b53e-dcf6900197c1)
