### PR TITLE
Add a query parameter to enable modifying url of VectorTileLayer to filter features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dash-leaflet",
-  "version": "1.0.17rc2",
+  "version": "1.0.17rc2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dash-leaflet",
-      "version": "1.0.17rc2",
+      "version": "1.0.17rc2.5",
       "license": "MIT",
       "dependencies": {
         "@mapbox/vector-tile": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dash-leaflet",
-  "version": "1.0.15",
+  "version": "1.0.17rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dash-leaflet",
-      "version": "1.0.15",
+      "version": "1.0.17rc2",
       "license": "MIT",
       "dependencies": {
         "@mapbox/vector-tile": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-leaflet",
-  "version": "1.0.17rc2",
+  "version": "1.0.17rc2.5",
   "description": "Dash Leaflet is a light wrapper around React-Leaflet. The syntax is similar to other Dash components, with naming conventions following the React-Leaflet API.",
   "main": "index.ts",
   "repository": {

--- a/src/ts/react-leaflet/VectorTileLayer.ts
+++ b/src/ts/react-leaflet/VectorTileLayer.ts
@@ -9,7 +9,7 @@ import {
 import { default as leafletVectorTileLayer } from 'leaflet-vector-tile-layer'
 import { DashFunction, Modify, resolveProps, TileLayerProps } from "../props";
 import { omit, pick } from "../utils";
-import { GridLayer, TileLayer } from 'leaflet';
+import { GridLayer, TileLayer, TileLayerOptions } from 'leaflet';
 
 export type VectorTileLayerOptions = {
     /**
@@ -89,7 +89,9 @@ export type VectorTileLayerProps = Modify<TileLayerProps, {
 
 const _funcOptions = ["featureToLayer", "filter", "layerOrder", "style"]
 
-const q = new URLSearchParams({});
+interface ExtendedTileLayerOptions extends TileLayerOptions {
+    q?: URLSearchParams;
+}
 
 export const VectorTileLayer = createTileLayerComponent<
     TileLayer,  // MAKE PROPER CLASS (might be equal though?)
@@ -97,6 +99,8 @@ export const VectorTileLayer = createTileLayerComponent<
 >(
     
     function createTileLayer({ url, ...options }, context) {
+        const q = new URLSearchParams({});
+
         if (options.query != null) {
             for (const [key, value] of Object.entries(options.query)) {
                 q.append(key,value);
@@ -114,7 +118,8 @@ export const VectorTileLayer = createTileLayerComponent<
         if (query != null && JSON.stringify(query) != JSON.stringify(prevProps.query)) {
 
             const new_query_keys = Object.keys(query);
-            
+            const q = (layer.options as ExtendedTileLayerOptions).q;
+            const _oldKeyToRemove = [];
             // loop through the old query
             q.forEach((value, key) => {
                 if (new_query_keys.includes(key)) {
@@ -123,9 +128,15 @@ export const VectorTileLayer = createTileLayerComponent<
                     }
                 }
                 else {
-                    q.delete(key);
+                    _oldKeyToRemove.push(key);
                 }
             });
+
+            for (let _key of _oldKeyToRemove) {
+                if (_key != null) {
+                    q.delete(_key);
+                }
+            }
 
             // loop through new query
             for (const [key, value] of Object.entries(query)) {

--- a/src/ts/react-leaflet/VectorTileLayer.ts
+++ b/src/ts/react-leaflet/VectorTileLayer.ts
@@ -74,8 +74,8 @@ export type VectorTileLayerOptions = {
 
     /**
      * Passing a Python dictionary, this dictionary will be turned into 
-     * a URLSearchParams JavaScript object, which will be a part of url
-     * https://xyz/collections/public.building/tiles/WebMercatorQuad/{z}/{x}/{y}?{query}
+     * a URLSearchParams JavaScript object, which will correspond to {q} in the following url
+     * https://xyz/collections/schema.table/tiles/WebMercatorQuad/{z}/{x}/{y}?{q}
      */
     query?: object;
 }
@@ -89,7 +89,7 @@ export type VectorTileLayerProps = Modify<TileLayerProps, {
 
 const _funcOptions = ["featureToLayer", "filter", "layerOrder", "style"]
 
-const query_formatted = new URLSearchParams({});
+const q = new URLSearchParams({});
 
 export const VectorTileLayer = createTileLayerComponent<
     TileLayer,  // MAKE PROPER CLASS (might be equal though?)
@@ -99,12 +99,12 @@ export const VectorTileLayer = createTileLayerComponent<
     function createTileLayer({ url, ...options }, context) {
         if (options.query != null) {
             for (const [key, value] of Object.entries(options.query)) {
-                query_formatted.append(key,value);
+                q.append(key,value);
             }
         }
 
         const resolvedOptions = resolveProps(options, _funcOptions, context);
-        const layer = leafletVectorTileLayer(url, Object.assign({},withPane(resolvedOptions, context), {query_formatted}));
+        const layer = leafletVectorTileLayer(url, Object.assign({},withPane(resolvedOptions, context), {q}));
         return createElementObject(layer, context);
     },
     function updateTileLayer(layer, props, prevProps) {
@@ -112,29 +112,25 @@ export const VectorTileLayer = createTileLayerComponent<
         const { query } = props
         // TODO: Double check property stuff here
         if (query != null && JSON.stringify(query) != JSON.stringify(prevProps.query)) {
-            console.log("Current query");
-            console.log(query);
-            console.log("Previous query");
-            console.log(prevProps.query);
 
             const new_query_keys = Object.keys(query);
             
             // loop through the old query
-            query_formatted.forEach((value, key) => {
+            q.forEach((value, key) => {
                 if (new_query_keys.includes(key)) {
                     if (query[key] !== value) {
-                        query_formatted.set(key, query[key]);
+                        q.set(key, query[key]);
                     }
                 }
                 else {
-                    query_formatted.delete(key);
+                    q.delete(key);
                 }
             });
 
             // loop through new query
             for (const [key, value] of Object.entries(query)) {
-                if (!query_formatted.has(key)) {
-                    query_formatted.append(key,value);
+                if (!q.has(key)) {
+                    q.append(key,value);
                 }
             }
 


### PR DESCRIPTION
**Why is this feature needed?**

- Allow users to interactively filter features in vector tile layer, given that hideout property is not introduced to vector tile layer yet

**Why is current version not suitable for the needs?**

- Line [100](https://github.com/emilhe/dash-leaflet/blob/18ff4f08b3c314f0fa47972a087778eeecdfe4ad/src/ts/react-leaflet/VectorTileLayer.ts#L100) of VectorTileLayer.ts uses layer.setUrl(url) method, but this method is not available and will throw error
- Joachim, the author of Leaflet.VectorTileLayer [suggests](https://gitlab.com/jkuebart/Leaflet.VectorTileLayer/-/merge_requests/20)  
  - URL template string can have an extra {q} in addition to {x}, {y}, {z}
  - If we initialize a const URLSearchParams with a name such as q, and pass this const directly as an element in options when initializing VectorTileLayer, then we will be able to update the layer by modifying the key/value in the const q
  - To make the update take effect immediately, use layer.redraw() method

**With the new changes, how to do the filter then?**

The vector tile server needs to support [CQL](https://docs.geoserver.org/2.24.x/en/user/tutorials/cql/cql_tutorial.html) in order to perform filtering by passing different URL. Here I use [TiPG](https://developmentseed.org/tipg/user_guide/endpoints/#features) for testing the functionality.

1. Initialize the layer within the map container
```
dl.VectorTileLayer(url="https://<TileServerEndpointURL>/collections/<SCHEMA.TABLE>/tiles/WebMercatorQuad/{z}/{x}/{y}?{q}",
                             id="vectortile",
                             query={
                                    "properties": "res,comind,geometry",
                                    "filter-lang": "cql2-text",
                                    "filter": "res IS NULL AND comind IS NULL"
                                    })
```
Note in the above code, the url ends with `?{q}`, this format must be strictly followed if you want to perform filtering. If you do not expect to use filtering functionality, you can choose to specify the url without `?{q}` at the end.

Additionally, to perform filtering, the `query` parameter needs to be specified. This parameter assumes a dictionary-like object. In this example, `"properties": "res,comind,geometry"` means to select those three columns from the PostGIS table. `"filter-lang": "cql2-text"` specifies the filter language, and `"filter": "res IS NULL AND comind IS NULL"` is like a SQL where clause that selects only features with both res and comind fields having null values. Note that those specific query parameters are tile server dependent and please consult the documentation of the tile server that you are using. I also want to mention that TiPG seems to assume column names to be all lower case.

2. Create a callback function to update the query parameter of VectorTileLayer
```
@callback(
    Output("vectortile","query"),
    [Input("map","zoom")],
    State("vectortile","query")
)
def updatebuildinglayer(zoomlevel,current_url):
    expected_url = {
        "properties": "res,comind,geometry",
        "filter-lang": "cql2-text",
        "filter": "res = '0'"
    }
    if expected_url != current_url:
        return expected_url
    
    return dash.no_update
```


