### PR TITLE
Fix event names of EditControl, closes #264

### DIFF
--- a/src/ts/components/EditControl.tsx
+++ b/src/ts/components/EditControl.tsx
@@ -61,7 +61,7 @@ function _getDefaultEventHandlers(props) {
         }, 1);
     }
     // Bind action events.
-    const actionEvents = ['draw:drawStart', 'draw:drawStop', 'draw:deleteStart', 'draw:deleteStop', 'draw:editStart', 'draw:editStop'];
+    const actionEvents = ['draw:drawstart', 'draw:drawstop', 'draw:deletestart', 'draw:deletestop', 'draw:editstart', 'draw:editstop'];
     for (const actionEvent of actionEvents) {
         eventHandlers[actionEvent] = (e) => {
             props.setProps({


### PR DESCRIPTION
The event names are updated to be consistent with react-leaflet-draw