### PR TITLE
allow custom toolbar tooltips on EditControl component

### DIFF
--- a/src/ts/react-leaflet/EditControl.ts
+++ b/src/ts/react-leaflet/EditControl.ts
@@ -92,7 +92,9 @@ function createEditControl(){
             options["position"] = position;
         }
         if (buttons) {
-            L.drawLocal.draw.toolbar.buttons = buttons;
+            L.drawLocal.draw.toolbar.buttons = {
+                ...L.drawLocal.draw.toolbar.buttons, ...buttons
+            }
         }
         return createElementObject(new L.Control.Draw(options), ctx)
     }


### PR DESCRIPTION
I'd like to propose a new option to the EditControl component which allows to customize the tooltip shown when hovering on the draw buttons. Here's an example screenshot of what it looks like.
![image](https://github.com/user-attachments/assets/2a821bd7-a4f8-443a-ad07-05a5602c897b)

MWE:

```
from dash import Dash
import dash_leaflet as dl


app = Dash()
app.layout = [
        dl.Map(
            [
                dl.TileLayer(),
                dl.FeatureGroup(
                    [
                        dl.EditControl(
                            buttons={
                                "rectangle": "new tooltip",
                            },
                        ),
                    ],
                ),
            ],
            center=[56, 10], zoom=6, style={"height": "50vh"},
        )
        ]

if __name__ == "__main__":
    app.run(debug=True)
```