### PR TITLE
fix: drop pin on buff packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "dash>=3.0.0",
     "dash-extensions>=2.0.0",
     "dash_svg",
-    "protobuf==3.20.0",
-    "geobuf==1.1.1",
+    "protobuf",
+    "geobuf",
     "pyyaml",
     "colorcet",
 ]


### PR DESCRIPTION
FIx #281 

I'm curious to see how it goes if you release the pin on these dependencies.